### PR TITLE
add contributor GitHub links on all projects, typo edit on ROADMAP

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -6,43 +6,51 @@ credit where credit is due.
 
 ## AspireCloud
 
-* [Sarah Savage](https://github.com/sarah-savage), Team Lead
+- [Chuck Adams](https://github.com/chuckadams), Team Lead
+- [Sarah Savage](https://github.com/sarah-savage)
+- [AspireCloud Contributors](https://github.com/aspirepress/AspireCloud/graphs/contributors)
 
 ## AspireSync
 
-* [Sarah Savage](https://github.com/sarah-savage), Team Lead
-* [Chuck Adams](https://github.com/chuckadams)
+- [Chuck Adams](https://github.com/chuckadams), Team Lead
+- [Sarah Savage](https://github.com/sarah-savage)
+- [AspireSync Contributors](https://github.com/aspirepress/AspireSync/graphs/contributors)
 
 ## AspireUpdate
 
-* [Alex Sirota](https://github.com/asirota), Team Lead
-* [Namith Jawahar](https://github.com/namithj)
-* [Sarah Savage](https://github.com/sarah-savage)
+- [Alex Sirota](https://github.com/asirota), Team Lead
+- [Namith Jawahar](https://github.com/namithj), Lead Developer
+- [Sarah Savage](https://github.com/sarah-savage)
+- [AspireUpdate Contributors](https://github.com/aspirepress/AspireUpdate/graphs/contributors)
 
 ## AspirePress.org
-* 
-* [Matt Leach](https://github.com/mattleach89), Team Lead
-* [Kyle Keevill](https://github.com/kylek14)
-* [Sarah Savage](https://github.com/sarah-savage)
+
+- [Matt Leach](https://github.com/mattleach89), Team Lead
+- [Kyle Keevill](https://github.com/kylek14)
+- [Sarah Savage](https://github.com/sarah-savage)
+- [AspirePress.org Contributors](https://github.com/aspirepress/site-theme/graphs/contributors)
 
 ## Governance
 
-Being determined.
+Work in Progress
 
 ## Hosting & Services
 
 This lists service providers that provide free or discounted services to AspirePress for hosting and/or distribution.
 
-* [WPConcierge](https://wpconcierge.com), AspirePress.org website
-* Tailwinds, LLC, domain name registration (yearly)
+- [WPConcierge](https://wpconcierge.com), AspirePress.org website
+- Tailwinds, LLC, domain name registration (yearly)
+- [Fastly](https://www.fastly.com/), CDN services
 
 ## Financial Backers
 
 This is a list of financial backers who have given $1,000 or more in the last 12 months.
 
-* [Sarah Savage](https://sarah-savage.com) - $1,000
-* [WPConcierge](https://wpconcierge.com) - $1,000
+- [Sarah Savage](https://sarah-savage.com) - $1,000
+- [WPConcierge](https://wpconcierge.com) - $1,000
 
-## Special Thanks To
+[AspirePress Sponsors](https://github.com/sponsors/aspirepress)
 
-* [Matt Leach](https://github.com/mattleach89) and [Other Half Digital](https://otherhalf.digital) for their generous donation of logos for AspirePress.
+## Special thanks to...
+
+- [Matt Leach](https://github.com/mattleach89) and [Other Half Digital](https://otherhalf.digital) for their generous donation of logos for AspirePress.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,30 +9,30 @@ AspirePress is building AspireCloud, which is a mirroring and repository system 
 
 The following terms apply through this document:
 
-* **Mirror** - An endpoint that replicates a list of packages and/or downloadable packages themselves.
-* **Repository** - An endpoint that replicates the package data itself.
-* **Package** - A package is either a plugin or a theme, which will be distributed by the network.
-* **Network** - A loosely federated group of mirrors and repositories that exchange information for the purpose of
+- **Mirror** - An endpoint that replicates a list of packages and/or downloadable packages themselves.
+- **Repository** - An endpoint that replicates the package data itself.
+- **Package** - A package is either a plugin or a theme, which will be distributed by the network.
+- **Network** - A loosely federated group of mirrors and repositories that exchange information for the purpose of
   coordinating and providing a comprehensive list of available assets in the WordPress ecosystem.
-* **Asset** - An asset is the combined metadata and package information that is hosted by a mirror or repository.
-* **Endpoint** - A server or collection of servers that provide compute for the upgrade and install process in
+- **Asset** - An asset is the combined metadata and package information that is hosted by a mirror or repository.
+- **Endpoint** - A server or collection of servers that provide compute for the upgrade and install process in
   WordPress.
-* **CDN** - A CDN is used to distribute the load of downloading packages and mitigate the risks of malware or DDOS.
+- **CDN** - A CDN is used to distribute the load of downloading packages and mitigate the risks of malware or denial of service attacks (DDOS).
 
 ## Basic functions of mirrors/repositories
 
 A mirror or repository (in this section referred to as a "resository") has the following responsibilities:
 
-* Serve requests from constituents (WordPress instances) that request information about available packages or available
+- Serve requests from constituents (WordPress instances) that request information about available packages or available
   package updates.
-* Provide endpoints for the publication of packages from authors that have authenticated with that repository.
-* Distribute metadata about the details of packages, versions of those packages, and where to download those package
+- Provide endpoints for the publication of packages from authors that have authenticated with that repository.
+- Distribute metadata about the details of packages, versions of those packages, and where to download those package
   files.
-* Receive and update internal records related to authenticated packages from other mirrors.
-* Decide which packages to provide and which to hold back.
-* Determine which packages to download from the canonical repository, and which to refer to the canonical repository.
-* Identify and peer with (or decline to peer with) other repositories.
-* Share all information with peer repositories on request.
+- Receive and update internal records related to authenticated packages from other mirrors.
+- Decide which packages to provide and which to hold back.
+- Determine which packages to download from the canonical repository, and which to refer to the canonical repository.
+- Identify and peer with (or decline to peer with) other repositories.
+- Share all information with peer repositories on request.
 
 ## WordPress update functionality
 
@@ -41,7 +41,7 @@ new package or update for an old package. Every mirror must implement a WordPres
 information.
 
 Since the APIs are essentially defined within WordPress itself, each repository **MUST** implement the same
-specification as WordPress expects. However, the repository *MAY* provide additional information as part of its
+specification as WordPress expects. However, the repository _MAY_ provide additional information as part of its
 response. That information would be ignored by WordPress.
 
 ## Package publication
@@ -90,11 +90,11 @@ metadata **MUST** include an endpoint where the package may be located and acqui
 
 For repositories that opt for full distribution, they **MUST** comply with the following rules:
 
-* They must inform other repositories that they are a source (but a non-canonical source) for the package, to ensure
+- They must inform other repositories that they are a source (but a non-canonical source) for the package, to ensure
   network durability.
-* They must store and check the authenticity and completeness of the package, and reject packages that fail to
+- They must store and check the authenticity and completeness of the package, and reject packages that fail to
   authenticate or are incomplete.
-* They must serve the metadata AND the files for the package on request.
+- They must serve the metadata AND the files for the package on request.
 
 ## Peering and Network Security
 
@@ -108,23 +108,23 @@ similarity to existing packages to create confusion and permit attack.
 
 To prevent against this, the following rules apply:
 
-* Unless a package comes directly from the original .org repo, the package **MUST** have a namespace. The namespace is
+- Unless a package comes directly from the original .org repo, the package **MUST** have a namespace. The namespace is
   published by the repository when peering, cannot be changed, and must be provided with any package for which it is
   canonical. For example AspireCloud's first-person repository namespace would be `aspire`.
-* Repositories may accept or reject other repositories from which they permit or refuse traffic. Under circumstances
+- Repositories may accept or reject other repositories from which they permit or refuse traffic. Under circumstances
   where a repository is attempting a DDOS attack against the other repositories (e.g. publishing packages that are
   illegitimate for the purposes of flooding other repositories), a repository owner has the right to outright block
   acess to their infraustructure by the offending repository.
-* A repository may specify what level it accepts from specific repositories. For example, a repository may be accepted
+- A repository may specify what level it accepts from specific repositories. For example, a repository may be accepted
   as a non-canonical source, but refuse to accept canonical packages for security reasons.
-* A repository may choose not to distribute ANY packages or assets from a particular repository if it so desires.
-* A repository must authenticate requests from repositories through public-private key encryption prior to accepting any
+- A repository may choose not to distribute ANY packages or assets from a particular repository if it so desires.
+- A repository must authenticate requests from repositories through public-private key encryption prior to accepting any
   data or federation from a new repository.
-* Repositories may implement review rules and require other repositories to adhere to them for listing of packages in
+- Repositories may implement review rules and require other repositories to adhere to them for listing of packages in
   their repository.
-* Repositories may also implement their own rules and/or review package update information for adherance to their
+- Repositories may also implement their own rules and/or review package update information for adherance to their
   rulesets.
-* Repositories will always prefer the canonical source over non-canoncical sources, and compare checksums of
+- Repositories will always prefer the canonical source over non-canoncical sources, and compare checksums of
   non-canonical sources to ensure package secuirty and authenticity.
 
 ## Shared information


### PR DESCRIPTION
# Pull Request

## What changed?

Added direct links to GitHub repo contributor lists, typo edit on ROADMAP

## Why did it change?

to give linked credit to code contributors on projects and make sure visitors to GitHub and AspirePress.org know who is involved on an ongoing basis

## Did you fix any specific issues?

typo on ROADMAP

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.