### PR TITLE
Update SECURITY advisory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
 # Security
 
-If you observe a security vulnerability in one of our packages or libraries, please responsibly report it to support@aspirepress.org. We will respond to notify you that we received your query, and we will credit you in the fix we provide. We ask for 30 days to fix any vulnerability before you disclose it.
+If you observe a security vulnerability in any of our projects, please responsibly report it by opening a new security advisory within the project repository. The project lead or manager will respond to discuss the issue with you, and AspirePress will credit you in the fix shoild one be published.
+
+We ask for 30 calendar days to fix any serious vulnerability before disclosure to AspirePress. AspirePress asks for any vulnerabilties not to be shared publicly.


### PR DESCRIPTION
Rewrite to remove email address and provide new advisory. Could be a model for a project wide advisory.

# Pull Request

## What changed?

Remove email added new wording 

## Why did it change?

Use GitHub security advisory process not email 

## Did you fix any specific issues?


#21 
## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

